### PR TITLE
Hide ejection angle labels when they are behind you

### DIFF
--- a/TransferWindowPlanner2/UI/Rendering/MapAngleRenderer.cs
+++ b/TransferWindowPlanner2/UI/Rendering/MapAngleRenderer.cs
@@ -203,19 +203,25 @@ public class MapAngleRenderer : MonoBehaviour
             ScaledSpace.LocalToScaledSpace(
                 center + length * VectorToUnityFrame(PeriapsisDirection.normalized)));
 
-        GUI.Label(
-            new Rect(
-                periapsis.x - 50,
-                Screen.height - periapsis.y - 15,
-                100, 30),
-            $"Burn position", _styleLabelEnd);
+        if (periapsis.z > 0)
+        {
+            GUI.Label(
+                new Rect(
+                    periapsis.x - 50,
+                    Screen.height - periapsis.y - 15,
+                    100, 30),
+                $"Burn position", _styleLabelEnd);
+        }
 
-        GUI.Label(
-            new Rect(
-                asymptote.x - 50,
-                Screen.height - asymptote.y - 15,
-                100, 30),
-            "Escape direction", _styleLabelTarget);
+        if (asymptote.z > 0)
+        {
+            GUI.Label(
+                new Rect(
+                    asymptote.x - 50,
+                    Screen.height - asymptote.y - 15,
+                    100, 30),
+                "Escape direction", _styleLabelTarget);
+        }
     }
 }
 }


### PR DESCRIPTION
Without this, the labels will appear in front of the camera again, which looks very strange. Found this bug when working on the LTP remake.

Tested to be working in-game
![image](https://github.com/user-attachments/assets/de5a7d06-4c53-4e8c-b52c-d37b34683f1c)
![image](https://github.com/user-attachments/assets/e34d40b6-b271-48f2-8545-2f6d642f24ef)
